### PR TITLE
Add lookahead PID controller

### DIFF
--- a/controllers/lookahead_pid.py
+++ b/controllers/lookahead_pid.py
@@ -1,0 +1,30 @@
+from . import BaseController
+import numpy as np
+
+class Controller(BaseController):
+    """PID controller augmented with a simple lookahead feedforward term."""
+    def __init__(self, kp=0.3, ki=0.05, kd=-0.1, kf=0.1, lookahead=10):
+        self.kp = kp
+        self.ki = ki
+        self.kd = kd
+        self.kf = kf
+        self.lookahead = lookahead
+        self.error_integral = 0.0
+        self.prev_error = 0.0
+
+    def update(self, target_lataccel, current_lataccel, state, future_plan):
+        error = target_lataccel - current_lataccel
+        self.error_integral += error
+        error_diff = error - self.prev_error
+        self.prev_error = error
+
+        ff = 0.0
+        if future_plan is not None and len(future_plan.lataccel) > 0:
+            ff = np.mean(future_plan.lataccel[: self.lookahead]) - current_lataccel
+
+        return (
+            self.kp * error
+            + self.ki * self.error_integral
+            + self.kd * error_diff
+            + self.kf * ff
+        )


### PR DESCRIPTION
## Summary
- add a lookahead PID controller that blends a simple feedforward term from the future plan

## Testing
- `python -m py_compile controllers/*.py`
- `python - <<'EOF'
import pandas as pd, numpy as np
from tinyphysics import run_rollout
rows=520
df=pd.DataFrame({'roll':np.zeros(rows),'vEgo':np.ones(rows)*15,'aEgo':np.zeros(rows),'targetLateralAcceleration':np.sin(np.linspace(0,10,rows)),'steerCommand':np.zeros(rows)})
fname='tmp.csv'; df.to_csv(fname,index=False); res,_,_=run_rollout(fname,'lookahead_pid','models/tinyphysics.onnx'); print(res)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_683e14a4fe708322afdb7b4481f552a6